### PR TITLE
chore: use `DataPayload` as input/output format for `Execute()`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13
+	github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -63,10 +63,10 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
-github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e h1:s2gsgcINuuedPF/iQKzsMlaGQMO2I5dGj98XuIs+3uk=
-github.com/instill-ai/connector v0.0.0-20230607085408-06a038e17b8e/go.mod h1:JQSmkMUh4dWHjL+BXwCbQvJfIOEr5D57iiGasr4xTaI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13 h1:qC0Xe0zCpmgq02vClxL4OS1ZLjDmFUn/KuJOtJxINmI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230523000406-299e9451af13/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
+github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb h1:2COcd1xqha168hbcFJW7RXoqop/T52Z2NYuToRBeoXI=
+github.com/instill-ai/connector v0.0.0-20230615093707-edf8710c4ddb/go.mod h1:njRy7QkM8b5tnDihZdpZy8tfN86Sz8a26VEMPM8sRFQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd h1:Tu2JRlXKZpC5AfoZO23xf8AkDZxvxqr/Ve+Yw1GtKS8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230615091607-d5e75c7bc0dd/go.mod h1:7/Jj3ATVozPwB0WmKRM612o/k5UJF8K9oRCNKYH8iy0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=

--- a/pkg/instill/pull/main.go
+++ b/pkg/instill/pull/main.go
@@ -40,7 +40,7 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	}, nil
 }
 
-func (con *Connection) Execute(input interface{}) (interface{}, error) {
+func (con *Connection) Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
 	return input, nil
 }
 func (con *Connection) Test() (connectorPB.Connector_State, error) {

--- a/pkg/instill/request/main.go
+++ b/pkg/instill/request/main.go
@@ -59,7 +59,7 @@ func (c *Connector) CreateConnection(defUid uuid.UUID, config *structpb.Struct, 
 	}, nil
 }
 
-func (con *Connection) Execute(input interface{}) (interface{}, error) {
+func (con *Connection) Execute(input []*connectorPB.DataPayload) ([]*connectorPB.DataPayload, error) {
 	return input, nil
 }
 


### PR DESCRIPTION
Because

- we defined a unified format for interchange data in pipeline

This commit

- use `DataPayload` as input/output format for `Execute()`
