### PR TITLE
fix(definition): fix http source definition icon field

### DIFF
--- a/pkg/instill/request/config/seed/definitions.json
+++ b/pkg/instill/request/config/seed/definitions.json
@@ -2,7 +2,7 @@
   {
     "custom": false,
     "documentationUrl": "https://www.instill.tech/docs/source-connectors/http",
-    "icon": "grpc.svg",
+    "icon": "http.svg",
     "iconUrl": "",
     "id": "source-http",
     "public": true,


### PR DESCRIPTION
Because

- The http definition icon field is wrong

This commit

- fix http source definition icon field
