### PR TITLE
chore: merge `source-http` and `source-grpc` to `trigger`

### DIFF
--- a/pkg/instill/request/config/seed/definitions.json
+++ b/pkg/instill/request/config/seed/definitions.json
@@ -1,48 +1,25 @@
 [
   {
     "custom": false,
-    "documentationUrl": "https://www.instill.tech/docs/source-connectors/http",
-    "icon": "http.svg",
+    "documentationUrl": "https://www.instill.tech/docs/source-connectors/trigger",
+    "icon": "trigger.svg",
     "iconUrl": "",
-    "id": "source-http",
+    "id": "trigger",
     "public": true,
     "spec": {
-      "documentationUrl": "https://www.instill.tech/docs/source-connectors/http",
+      "documentationUrl": "https://www.instill.tech/docs/source-connectors/trigger",
       "connectionSpecification": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "http Source Connector Spec",
+        "title": "Trigger Connector Spec",
         "type": "object",
         "required": [],
         "additionalProperties": false,
         "properties": {}
       }
     },
-    "title": "http",
+    "title": "Trigger",
     "tombstone": false,
     "uid": "f20a3c02-c70e-4e76-8566-7c13ca11d18d",
-    "vendorAttributes": {}
-  },
-  {
-    "custom": false,
-    "documentationUrl": "https://www.instill.tech/docs/source-connectors/grpc",
-    "icon": "grpc.svg",
-    "iconUrl": "",
-    "id": "source-grpc",
-    "public": true,
-    "spec": {
-      "documentationUrl": "https://www.instill.tech/docs/source-connectors/grpc",
-      "connectionSpecification": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "title": "gRPC Source Connector Spec",
-        "type": "object",
-        "required": [],
-        "additionalProperties": false,
-        "properties": {}
-      }
-    },
-    "title": "gRPC",
-    "tombstone": false,
-    "uid": "82ca7d29-a35c-4222-b900-8d6878195e7a",
     "vendorAttributes": {}
   }
 ]


### PR DESCRIPTION
Because

- it is not user-friendly to have separated `http` and `grpc` connector

This commit

- merge `source-http` and `source-grpc` to `trigger`
