### PR TITLE
chore: update connector pkg and use connector Task enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.1.0-alpha
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2
+	github.com/instill-ai/connector v0.1.0-alpha.0.20230717104353-9833ed07cd2e
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,10 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2 h1:I/pwhnUln5wbMnTyRbzswA0/JxpK8sZj0aUfI3TV1So=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.2/go.mod h1:lsuH8kb4GlMdSlI4alNIBBSAt5CHJtg3i+0WuN9J5YM=
-github.com/instill-ai/connector v0.1.0-alpha h1:q80MU2bhFGf5puUPtrHhPL+Y7StjDyE0i48bvepg/M0=
-github.com/instill-ai/connector v0.1.0-alpha/go.mod h1:ctro5UDPVoLV7Toi6/cOar0JpYKtabvpXWmjtrXbce4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2 h1:e8AG+hOq2FkIz2IRq+lEJBWKY3BhzgpmjOTHVVMBEcY=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230628145744-8bd74278dff2/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.1.0-alpha.0.20230717104353-9833ed07cd2e h1:DJP5mRLcT1ViNgGCgn/orzMlFLQrv1ySPN0OVKid6UA=
+github.com/instill-ai/connector v0.1.0-alpha.0.20230717104353-9833ed07cd2e/go.mod h1:3kLmWi+0vdp4PfjRrolQQwOXU55HG1e1N9J7y83MBhw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf h1:E2D/N87Xcv+srNlr6BO8NvaLnLE+/F5QXgW140RWNVY=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230717101605-87e3b68be4cf/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/instill/pull/main.go
+++ b/pkg/instill/pull/main.go
@@ -47,6 +47,6 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	return connectorPB.Connector_STATE_UNSPECIFIED, nil
 }
 
-func (con *Connection) GetTaskName() (string, error) {
-	return "TASK_UNSPECIFIED", nil
+func (con *Connection) GetTask() (connectorPB.Task, error) {
+	return connectorPB.Task_TASK_UNSPECIFIED, nil
 }

--- a/pkg/instill/request/main.go
+++ b/pkg/instill/request/main.go
@@ -69,6 +69,6 @@ func (con *Connection) Test() (connectorPB.Connector_State, error) {
 	return connectorPB.Connector_STATE_CONNECTED, nil
 }
 
-func (con *Connection) GetTaskName() (string, error) {
-	return "TASK_UNSPECIFIED", nil
+func (con *Connection) GetTask() (connectorPB.Task, error) {
+	return connectorPB.Task_TASK_UNSPECIFIED, nil
 }


### PR DESCRIPTION
Because

- we need to explicitly use `Task` enum instead of just string

This commit

- update connector pkg version and use connector `Task` enum
